### PR TITLE
Remove extra column in table header

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ To submit a new plugin read [CONTRIBUTING.md](./CONTRIBUTING.md) first.
 
 **[`^        back to top        ^`](#awesome-vim9)**
 
-| Name | URL | Description | Maintained |
-| --- | --- | --- | --- |
+| Name | Description | Maintained |
+| --- | --- | --- |
 | [vim-shout](https://github.com/habamax/vim-shout) | Run and Capture Shell Command Output in Vim | ✅ |
 
 ## Completion


### PR DESCRIPTION
Seems like the top example has 4 columns in the header and one in the body.