### PR TITLE
Add vim9-autopairs to contributions list

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -19,6 +19,7 @@ https://github.com/mityu/vim-wispath
 
 https://github.com/Coacher/vim9-buckler
 https://github.com/Coacher/vim9-cutlass
+https://github.com/nda-cunh/vim9-autopairs
 https://github.com/Eliot00/auto-pairs
 https://github.com/ubaldot/vim-highlight-yanked
 https://github.com/ubaldot/vim-markdown-extras


### PR DESCRIPTION
I have ported https://github.com/jiangmiao/auto-pairs plugin in vim9script
because https://github.com/Eliot00/auto-pairs 
has some bugs and is not fully in vim9script, only small bits.
I needed it for my vim distro.  :)