### PR TITLE
Update link for SupraTree to SupraWater

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -30,7 +30,7 @@ https://github.com/ubaldot/vim-writegood
 # File Management
 
 https://github.com/habamax/vim-dir
-https://github.com/nda-cunh/SupraTree
+https://github.com/nda-cunh/SupraWater
 https://github.com/saccarosium/vim-netrw-salad
 https://github.com/ubaldot/vim-open-recent
 https://github.com/ycm/poplar.vim


### PR DESCRIPTION
I removed SupraTree because I recoded a new tree for vim (the real supratree), but it is not finished yet.

 SupraWater is just an instance buffer.
It's Nvim-Oil, I rewrote all of Water's code. It's now vim 9.1 instead of vim 9.0. 
It's faster, more stable, and more efficient, and I removed the tree mode.
<img width="761" height="275" alt="image" src="https://github.com/user-attachments/assets/85db83eb-e3e1-4dc7-b689-ffde0021c72e" />

Soon the  SupraTree is this:
<img width="440" height="876" alt="image" src="https://github.com/user-attachments/assets/2f486960-b54b-4d15-b736-67fe9df1863e" />
it will be half oil/ half nvim-tree